### PR TITLE
Publish docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: GitHub Pages
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main  # Set a branch name to trigger deployment
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: nox -s docs
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # If you're changing the branch from main,
+        # also change the `main` in `refs/heads/main`
+        # below accordingly.
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          publish_brash: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/_build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bluesky-cookbook
+
 Documentation for various use cases, ideas and "recipes" within the bluesky framework
 
 Each recipe should:
@@ -11,3 +12,10 @@ Each recipe should:
     * Developer
     * Admin
     * Manager
+
+## How to Build
+
+```
+pip install nox
+nox -s docs
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx_tags",
 ]
 
 source_suffix = [".rst", ".md"]
@@ -40,3 +41,5 @@ nitpick_ignore = [
 ]
 
 always_document_param_types = True
+
+tags_creat_tags = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+project = "Bluesky Cookbook"
+copyright = f"{datetime.now().year} Bluesky Contributors"
+author = "Bluesky Contributors"
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+]
+
+source_suffix = [".rst", ".md"]
+exclude_patterns = [
+    "_build",
+    "**.ipynb_checkpoints",
+    "Thumbs.db",
+    ".DS_Store",
+    ".env",
+    ".venv",
+]
+
+html_theme = "furo"
+
+myst_enable_extensions = [
+    "colon_fence",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+nitpick_ignore = [
+    ("py:class", "_io.StringIO"),
+    ("py:class", "_io.BytesIO"),
+]
+
+always_document_param_types = True

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Bluesky Cookbook
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+```
+
+## Table of Contents
+
+- {ref}`genindex`
+- {ref}`search`

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,47 @@
+import argparse
+
+import nox
+
+
+@nox.session(reuse_venv=True)
+def docs(session: nox.Session) -> None:
+    """
+    Build the docs. Pass "--serve" to serve. Pass "-b linkcheck" to check links.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true", help="Serve after building")
+    parser.add_argument(
+        "-b", dest="builder", default="html", help="Build target (default: html)"
+    )
+    args, posargs = parser.parse_known_args(session.posargs)
+
+    if args.builder != "html" and args.serve:
+        session.error("Must not specify non-HTML builder with --serve")
+
+    extra_installs = ["sphinx-autobuild"] if args.serve else []
+
+    session.install("-r", "requirements.txt")
+    if extra_installs:
+        session.install(*extra_installs)
+    session.chdir("docs")
+
+    if args.builder == "linkcheck":
+        session.run(
+            "sphinx-build", "-b", "linkcheck", ".", "_build/linkcheck", *posargs
+        )
+        return
+
+    shared_args = (
+        "-n",  # nitpicky mode
+        "-T",  # full tracebacks
+        f"-b={args.builder}",
+        ".",
+        f"_build/{args.builder}",
+        *posargs,
+    )
+
+    if args.serve:
+        session.run("sphinx-autobuild", *shared_args)
+    else:
+        session.run("sphinx-build", "--keep-going", *shared_args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ furo
+ myst_parser >=0.13
+ sphinx >=4.0
+ sphinx-copybutton
+ sphinx-autodoc-typehints


### PR DESCRIPTION
This PR adds a minimal sphinx confirmation and docs page.

Notes on some choices:

- This repo does not contain a Python package, and I opted not to make a placeholder "package" but instead make this a docs-only repo.
- In writing `conf.py` and choosing sphinx plugins, I made reference to https://learn.scientific-python.org/development/guides/docs/.
- I included a `noxfile.py` and recommended `nox -s docs` for building the docs. This nicely creates a virtualenv for building docs for you, and unlike `Makefile` is naturally cross-platform.
- I added `sphinx-tags`, as we had mentioned in our `README.md` planning to tag recipes by audience (user, developer, admin, manager).

The GHA is untested and may or may not require iteration after merge.