### PR TITLE
Typo in deployment workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html
-          publish_brash: gh-pages
+          publish_branch: gh-pages


### PR DESCRIPTION
With #14 merged, the built documentation was [expected to be at `https://blueskyproject.io/bluesky-cookbook`](https://blueskyproject.io/bluesky-cookbook) but that gives a `404`.

Looking at the deployment [logs](https://github.com/bluesky/bluesky-cookbook/actions/runs/9093725563/job/24993277692#step:5:1), I found:

```
Warning: Unexpected input(s) 'publish_brash', valid inputs are ['deploy_key', 'github_token', 'personal_token', 'publish_branch', 'publish_dir', 'destination_dir', 'external_repository', 'allow_empty_commit', 'keep_files', 'force_orphan', 'user_name', 'user_email', 'commit_message', 'full_commit_message', 'tag_name', 'tag_message', 'enable_jekyll', 'disable_nojekyll', 'cname', 'exclude_assets']
```

This PR fixes the typo.