### PR TITLE
Remove redundant conditional

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,6 @@ concurrency:
 jobs:
 
   build:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Build Jupyter Notebooks and HTML
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I think this line was meant to ensure that only _merged_ PRs get published, not just any PRs, but that is already ensured by `on:`

https://github.com/bluesky/bluesky-cookbook/blob/e641f38dda39deb3ddf7fe1239cc6b3a19a3b99a/.github/workflows/cd.yml#L4-L11